### PR TITLE
Fix React CDN after v16.0 release

### DIFF
--- a/dev.html
+++ b/dev.html
@@ -12,8 +12,8 @@
 
     <link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/hhnlfapopmaimdlldbknjdgekpgffmbo">
 
-    <script src="https://unpkg.com/react@latest/dist/react.js"></script>
-    <script src="https://unpkg.com/react-dom@latest/dist/react-dom.js"></script>
+    <script src="https://unpkg.com/react@15/dist/react.js"></script>
+    <script src="https://unpkg.com/react-dom@15/dist/react-dom.js"></script>
     <script src="https://unpkg.com/babel-standalone@6.15.0/babel.min.js"></script>
     
     <script type="text/javascript" src="js/jquery-2.1.1.min.js"></script>


### PR DESCRIPTION
Due to just released [React v16.0 packaging change](https://facebook.github.io/react/blog/2017/09/26/react-v16.0.html#packaging), the CDN path used in `dev.html` should be updated accordingly.

- `react/dist/react.min.js` → `react/umd/react.production.min.js`
- `react-dom/dist/react-dom.min.js` → `react-dom/umd/react-dom.production.min.js`

Considering no one has tested the project with React v16.0, this PR simply lock the CDN version at v15 as a workaround (was using `@latest` tag).