### PR TITLE
Chore/webpack import async

### DIFF
--- a/dev.html
+++ b/dev.html
@@ -7,13 +7,7 @@
     <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
-    <link rel="prefetch" href="conv/b2u_table.bin">
-    <link rel="prefetch" href="conv/u2b_table.bin">
-
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-    <% for (var css in htmlWebpackPlugin.files.css) { %>
-    <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
-    <% } %>
 
     <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
@@ -21,10 +15,6 @@
     <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js"></script>
-
-    <% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
-    <script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
-    <% } %>
   </head>
 
   <body>

--- a/js/main.js
+++ b/js/main.js
@@ -17,31 +17,19 @@ function startApp() {
   }, { from: from, keepAlive: keepAlive });
 }
 
-function loadTable(url) {
-  return new Promise(function(resolve, reject) {
-    $.ajax({
-      url: url,
-      processData: false,
-      xhrFields: {
-        responseType: 'arraybuffer'
-      }
-    }).done(function(data) {
-      resolve(data);
-    }).fail(function(jqXHR, textStatus, errorThrown) {
-      console.log('loadTable failed: ' + textStatus + ': ' + url);
-      reject();
-    });
-  });
+function base64ToUint8Array(it) {
+  return new Uint8Array([].map.call(atob(it), it => it.charCodeAt(0)))
 }
 
 function loadResources() {
   Promise.all([
-    loadTable('conv/b2u_table.bin'),
-    loadTable('conv/u2b_table.bin')
+    // Before (binary) 91.2 kB => After (base64) 98.4 kB
+    import('../conv/b2u_table.bin'/* webpackChunkName: "binary" */).then(base64ToUint8Array),
+    import('../conv/u2b_table.bin'/* webpackChunkName: "binary" */).then(base64ToUint8Array),
   ]).then(function(binData) {
     window.lib = window.lib || {};
-    window.lib.b2uArray = new Uint8Array(binData[0]);
-    window.lib.u2bArray = new Uint8Array(binData[1]);
+    window.lib.b2uArray = binData[0];
+    window.lib.u2bArray = binData[1];
     $(document).ready(startApp);
   }, function() {
     console.log('loadResources failed');

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "file-loader": "^1.1.5",
     "html-webpack-harddisk-plugin": "^0.1.0",
     "html-webpack-plugin": "^2.30.1",
+    "preload-webpack-plugin": "^2.0.0",
     "rimraf": "^2.6.2",
     "style-loader": "^0.19.0",
     "uglifyjs-webpack-plugin": "^0.4.6",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
+    "base64-loader": "^1.0.0",
     "cross-env": "^5.1.0",
     "css-loader": "^0.28.7",
     "extract-text-webpack-plugin": "^3.0.1",
@@ -22,9 +24,11 @@
     "presets": [["env"]],
     "env": {
       "development": {
+        "plugins": ["syntax-dynamic-import"],
         "presets": [["env"], ["react"]]
       },
       "production": {
+        "plugins": ["syntax-dynamic-import"],
         "presets": [["env"], ["react"]]
       }
     }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -48,6 +48,10 @@ export default {
         })
       },
       {
+        test: /\.bin$/,
+        loader: "base64-loader"
+      },
+      {
         test: /\.(bmp|png|woff)$/,
         loader: "file-loader"
       }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -4,6 +4,7 @@ import UglifyJSPlugin from 'uglifyjs-webpack-plugin';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import HtmlWebpackHarddiskPlugin from 'html-webpack-harddisk-plugin';
+import PreloadWebpackPlugin from 'preload-webpack-plugin';
 
 const DEVELOPER_MODE = process.env.NODE_ENV === 'development'
 const PRODUCTION_MODE = process.env.NODE_ENV === 'production'
@@ -76,7 +77,7 @@ export default {
         collapseWhitespace: PRODUCTION_MODE,
         removeComments: PRODUCTION_MODE
       },
-      inject: false,
+      inject: 'head',
       template: 'dev.html',
       filename: '../index.html'
     })
@@ -85,8 +86,9 @@ export default {
       sourceMap: true,
       parallel: true
     }),
+    new PreloadWebpackPlugin(),
   ] : [
-    new HtmlWebpackHarddiskPlugin()
+    new HtmlWebpackHarddiskPlugin(),
   ]),
   devServer: {
     proxy: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2964,7 +2964,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -3436,6 +3436,12 @@ postcss@^6.0.1:
     chalk "^2.1.0"
     source-map "^0.6.1"
     supports-color "^4.4.0"
+
+preload-webpack-plugin@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/preload-webpack-plugin/-/preload-webpack-plugin-2.0.0.tgz#a355614548400e29b75d5aa7a114cd63cd99c92d"
+  dependencies:
+    object-assign "^4.1.1"
 
 prepend-http@^1.0.0:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -389,6 +389,10 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
+
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
@@ -756,6 +760,10 @@ balanced-match@^1.0.0:
 base64-js@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
+
+base64-loader@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base64-loader/-/base64-loader-1.0.0.tgz#e530bad88e906dd2a1fad0af2d9e683fa8bd92a8"
 
 batch@0.6.1:
   version "0.6.1"


### PR DESCRIPTION
## Depends on 

~~#6~~

## Description

This PR:

* Move `.bin` files loading to be part of webpack async chunk
* Add preload features by applying `preload-webpack-plugin`

### The benefits

* Making it part of the webpack async chunk means we can use long-term caching by assigning `[chunkhash]` in the URL
* The `[chunkhash]` won't change until the contents of the chunk changes. It won't be affected by the main app
* Making it part of the explicit dependency graph

These can be proved by the screenshot:
<img width="1494" alt="screen shot 2017-10-25 at 11 22 38 pm" src="https://user-images.githubusercontent.com/922234/32135700-fde6e96a-bc35-11e7-8dc7-b4255b387432.png">

- Upper-left & Lower-left: change contents in `js/main.js`, and you can see the async chunk `0.b26…….js` is consistent
- Right part: auto-preload tag injected

### Size bloat after gzip

**98.4/(39+52) - 1 = 8%*

<img width="766" alt="screen shot 2017-10-25 at 11 10 33 pm" src="https://user-images.githubusercontent.com/922234/32135719-46c94e2a-bc36-11e7-8f4f-7c037607578d.png">



