### PR TITLE
Fix/webpack babel modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   "babel": {
     "env": {
       "development": {
-        "presets": [["env"], ["react"]]
+        "presets": [["env", { "modules": false }], ["react"]]
       },
       "production": {
-        "presets": [["env"], ["react"]]
+        "presets": [["env", { "modules": false }], ["react"]]
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "webpack-dev-server": "^2.9.3"
   },
   "babel": {
-    "presets": [["env"]],
     "env": {
       "development": {
         "presets": [["env"], ["react"]]

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -1,5 +1,5 @@
-module.exports = {};
-
 window.pttchrome = window.pttchrome || {};
 
 pttchrome.Constants = COMPILE_CONSTANTS;
+
+export const dummy = {}

--- a/src/js/en_US_messages.js
+++ b/src/js/en_US_messages.js
@@ -1,4 +1,4 @@
-exports.en_US = {
+export const en_US = {
   "appName": {
     "message": "PttChrome",
     "description": "The title of the application, displayed in the web store."

--- a/src/js/pttchrome.js
+++ b/src/js/pttchrome.js
@@ -1687,4 +1687,4 @@ pttchrome.App.prototype.setBBSCmd = function(cmd, cmdhandler) {
   }
 };
 
-exports.App = pttchrome.App;
+export const App = pttchrome.App;

--- a/src/js/symbol_table.js
+++ b/src/js/symbol_table.js
@@ -1,5 +1,5 @@
-exports.symbolTable = {};
-var a = exports.symbolTable;
+export const symbolTable = {};
+var a = symbolTable;
 a.xa1=1;
 a.xa0=1;
 a.xa1=1;

--- a/src/js/zh_TW_messages.js
+++ b/src/js/zh_TW_messages.js
@@ -1,4 +1,4 @@
-﻿exports.zh_TW = {
+﻿export const zh_TW = {
   "appName": {
     "message": "PttChrome",
     "description": "The title of the application, displayed in the web store."

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,9 @@
-import path from 'path';
-import webpack from 'webpack';
-import UglifyJSPlugin from 'uglifyjs-webpack-plugin';
-import ExtractTextPlugin from 'extract-text-webpack-plugin';
-import HtmlWebpackPlugin from 'html-webpack-plugin';
-import HtmlWebpackHarddiskPlugin from 'html-webpack-harddisk-plugin';
+const path = require('path');
+const webpack = require('webpack');
+const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const HtmlWebpackHarddiskPlugin = require('html-webpack-harddisk-plugin');
 
 const DEVELOPER_MODE = process.env.NODE_ENV === 'development'
 const PRODUCTION_MODE = process.env.NODE_ENV === 'production'
@@ -11,7 +11,7 @@ const PRODUCTION_MODE = process.env.NODE_ENV === 'production'
 const PAGE_TITLE = process.env.PTTCHROME_PAGE_TITLE || 'PttChrome';
 const DEFAULT_SITE = PRODUCTION_MODE ? 'wsstelnet://ws.ptt.cc/bbs' : 'wstelnet://localhost:8080/bbs'
 
-export default {
+module.exports = {
   entry: {
     'pttchrome': [
       './src/js/main.js',


### PR DESCRIPTION
## Description

* Reverts`webpack.config.babel.js` into `webpack.config.js` (introduced in #6 )
* So that we can make webpack consume ES modules directly in the source.