### PR TITLE
fix(components/ImagePreviewer): position preview with its true height

### DIFF
--- a/src/components/ImagePreviewer.js
+++ b/src/components/ImagePreviewer.js
@@ -95,14 +95,17 @@ ImagePreviewer.OnHover = ({ left, top, value, error }) => {
   if (error) {
     return false;
   } else if (value) {
+    const height = (this.dom && this.dom.height) || value.height;
+
     return (
       <img
+        ref={ref => (this.dom = ref)}
         src={value.src}
         style={{
           display: "block",
           position: "absolute",
           left: left + 20,
-          top: getTop(top, value.height),
+          top: getTop(top, height),
           maxHeight: "80%",
           maxWidth: "90%",
           zIndex: 2


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11714950/38343868-df0e9484-38b8-11e8-8c4e-5726106e7e3e.png)

圖片預覽目前是使用圖片原始的 size 計算位置

```javascript
export const resolveWithImageDOM = ({ src }) =>
// ...
    img.onload = () =>
      resolve({
        src,
        height: img.height
      });
```

但實際上 img 有設定`max-height: 80%; max-width: 90%;`
圖片有時並不這麼大
看表特版會跑版...很不方便

我嘗試調整成使用 dom 的 height
如果有任何需要修正的地方，請不要猶豫讓我知道
Thanks