### PR TITLE
Fix #43: fix(components/ImagePreviewer): resolve imgur url correctly

### DIFF
--- a/src/components/ImagePreviewer.js
+++ b/src/components/ImagePreviewer.js
@@ -193,13 +193,14 @@ registerImageUrlResolver({
   /*
    * imgur.com
    */
-  regex: /^https?:\/\/(i\.)?imgur\.com/,
+  regex: /^https?:\/\/(?:i\.)?imgur\.com\/([^.]+)(?:\.(.*))?/,
   test(src) {
     return this.regex.test(src);
   },
   request(src) {
+    const [_, photoId, extension = "jpg"] = this.regex.exec(src);
     return Promise.resolve({
-      src: `${src.replace(this.regex, "https://i.imgur.com")}.jpg`
+      src: `https://i.imgur.com/${photoId}.${extension}`
     });
   }
 });


### PR DESCRIPTION
## Description

Fix #43.

The old (imgur) image url resolver will convert `https://imgur.com/xxx.jpg` to `https://i.imgur.com/xxx.jpg.jpg`, which is incorrect.

Now it can handle urls with or without trailing filename extension.

## Related bugs

- [[-Fx-] term.ptt.cc - 看板 Browsers - 批踢踢實業坊](https://www.ptt.cc/bbs/Browsers/M.1529829828.A.F77.html)
- [Re: [-Fx-] term.ptt.cc - 看板 Browsers - 批踢踢實業坊](https://www.ptt.cc/bbs/Browsers/M.1529985221.A.C1A.html)
- [[問題] imgur 圖床在 term.ptt.cc 上的 BUG - 看板 PttBug - 批踢踢實業坊](https://www.ptt.cc/bbs/PttBug/M.1530362348.A.E05.html)