### PR TITLE
fix(js/pttchrome): prevent right click menu paste from breaking Firefox

### DIFF
--- a/src/js/pttchrome.js
+++ b/src/js/pttchrome.js
@@ -402,7 +402,7 @@ App.prototype.onDOMCopy = function(e) {
 };
 
 App.prototype.doPaste = function() {
-  if ('readText' in navigator.clipboard) {
+  if (navigator.clipboard && navigator.clipboard.readText) {
     navigator.clipboard.readText().then(
       (text) => this.onPasteDone(text),
       () => this.showPasteUnimplemented());


### PR DESCRIPTION
Fix #50, #51.