### PR TITLE
fix(components/ImagePreviewer): Prevent from negative top position

### DIFF
--- a/src/components/ImagePreviewer.js
+++ b/src/components/ImagePreviewer.js
@@ -82,8 +82,10 @@ const getTop = (top, height) => {
 
   // opening image would pass the bottom of the page
   if (top + height / 2 > pageHeight - 20) {
-    if (height / 2 < top) {
-      return pageHeight - 20 - height;
+    if (pageHeight - height >= 0) {
+      return pageHeight - height;
+    } else {
+      // TODO: Resize the image as it's larger than window.
     }
   } else if (top - 20 > height / 2) {
     return top - height / 2;


### PR DESCRIPTION
Example Bug: https://i.imgur.com/8hJoZTD.png

The current returned top position calculated by (pageHeight - 20 -
height) can be negative, leading to part of the image rendered outside
the screen. This commit fixes it by verifying if the difference of
windows height & image height is valid before returning.

A better fix would be resizing the image whenever necessary, which is
out of the scope of this commit.