### PR TITLE
fix(js/term_view): fix crash when user right-click while selecting all

### DIFF
--- a/src/js/term_view.js
+++ b/src/js/term_view.js
@@ -650,7 +650,7 @@ TermView.prototype = {
   },
 
   getRowLineElement: function(node) {
-    for (let r = node; r != r.parentNode; r = r.parentNode) {
+    for (let r = node; r && r != r.parentNode; r = r.parentNode) {
       if (r instanceof Element &&
         r.getAttribute('data-type') == 'bbsline') {
         return r;


### PR DESCRIPTION
If a user selects all using `Ctrl-A` or the `select all` option on the right-click menu and then right-click, the client will crash.
This issue occurs on **Chrome 78.0.3904.108** and **Firefox 70.0.1**.

This pull request fixes this issue.

These issues may be relevant: #50, #51.