### PR TITLE
Set lang="zh-Hant-TW" on the <html> element.

### DIFF
--- a/src/dev.html
+++ b/src/dev.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="zh-Hant-TW">
   <head>
     <title><%= process.env.PTTCHROME_PAGE_TITLE %></title>
     <link rel="icon" type="image/png" href="<%= require('./icon/logo.png') %>">


### PR DESCRIPTION
Setting the lang attribute to "zh-Hant-TW" (Traditional Chinese, Taiwan) hints to the browser that it should use a font suitable for Traditional Chinese in Taiwan.

Here are two screenshots taken on Chrome OS, where the OS language is set to English, from before and after this change:
Before: http://imgur.com/a/tveIe4S, which shows traditional characters from a font designed for China.
After: https://imgur.com/a/WUCK72d, which shows traditional characters from a font designed for Taiwan.

Note the differences in the top-right quadrant of "鍋" and in the last stroke of "亮", among others.