### PR TITLE
feat(term size): add max-font-size mode 新增最大字型大小模式

### DIFF
--- a/src/components/ContextMenu/PrefModal.js
+++ b/src/components/ContextMenu/PrefModal.js
@@ -331,6 +331,12 @@ export const PrefModal = ({
                       >
                         {i18n("options_fixedFontSize")}
                       </option>
+                      <option
+                        key={"options_maxFontSize"}
+                        value={"max-font-size"}
+                      >
+                        {i18n("options_maxFontSize")}
+                      </option>
                     </FormControl>
                   </FormGroup>
                   {(() => {
@@ -374,6 +380,20 @@ export const PrefModal = ({
                           <FormGroup controlId="fontSize">
                             <ControlLabel>
                               {i18n("options_fontSize")}
+                            </ControlLabel>
+                            <FormControl
+                              name="fontSize"
+                              type="number"
+                              value={values.fontSize}
+                              onChange={onNumberInputChange}
+                            />
+                          </FormGroup>
+                        );
+                      case "max-font-size":
+                        return (
+                          <FormGroup controlId="fontSize">
+                            <ControlLabel>
+                              {i18n("options_fontSizeMax")}
                             </ControlLabel>
                             <FormControl
                               name="fontSize"

--- a/src/js/en_US_messages.js
+++ b/src/js/en_US_messages.js
@@ -126,11 +126,17 @@ export const en_US = {
   "options_fontSize": {
     "message": "Font size (px)"
   },
+  "options_fontSizeMax": {
+    "message": "Maximum font size (px)"
+  },
   "options_fixedTermSize": {
     "message": "Fixed term size"
   },
   "options_fixedFontSize": {
     "message": "Fixed font size"
+  },
+  "options_maxFontSize": {
+    "message": "Maximum-limited font size"
   },
   "options_fontFitWindowWidth": {
     "message": "Stretch font to fill the view"

--- a/src/js/pttchrome.js
+++ b/src/js/pttchrome.js
@@ -757,6 +757,23 @@ App.prototype.onValuesPrefChange = function(values) {
         // Immediately recalc once.
         this.resizer();
         break;
+
+      case 'max-font-size':
+        this.view.fontFitWindowWidth = false;
+
+        let maxFontSize = values.fontSize;
+        let minSize = {cols: 80, rows: 24};
+        this.resizer = () => {
+          let scaledFontSize = this.view.calcFontSizeFromTerm(minSize.cols, minSize.rows);
+          let fontSize = Math.min(scaledFontSize, maxFontSize);
+          let size = this.view.calcTermSizeFromFont(fontSize);
+          this.setTermSize(size.cols, size.rows);
+          this.view.fixedResize(fontSize);
+          this.view.redraw(true);
+        };
+        // Immediately recalc once.
+        this.resizer();
+        break;
     }
 
     if (this.view.fontFitWindowWidth) {

--- a/src/js/term_view.js
+++ b/src/js/term_view.js
@@ -649,6 +649,16 @@ TermView.prototype = {
     };
   },
 
+  calcFontSizeFromTerm: function(termCols, termRows) {
+    termCols = Math.max(80, Math.min(200, termCols));
+    termRows = Math.max(24, Math.min(100, termRows));
+    let width = this.bbsWidth ? this.bbsWidth : this.innerBounds.width;
+    let height = this.bbsHeight ? this.bbsHeight : this.innerBounds.height;
+    let sizeX = Math.floor(2 * (width - 10) / termCols);
+    let sizeY = Math.floor(height / termRows);
+    return Math.min(sizeX, sizeY);
+  },
+
   getRowLineElement: function(node) {
     for (let r = node; r && r != r.parentNode; r = r.parentNode) {
       if (r instanceof Element &&

--- a/src/js/zh_TW_messages.js
+++ b/src/js/zh_TW_messages.js
@@ -126,11 +126,17 @@
   "options_fontSize": {
     "message": "字體大小 (px)"
   },
+  "options_fontSizeMax": {
+    "message": "最大字體大小 (px)"
+  },
   "options_fixedTermSize": {
     "message": "固定終端機大小"
   },
   "options_fixedFontSize": {
     "message": "固定字體大小"
+  },
+  "options_maxFontSize": {
+    "message": "限制最大字體大小"
   },
   "options_fontFitWindowWidth": {
     "message": "把字體拉大來補滿畫面"


### PR DESCRIPTION
The `max-font-size` mode behaviors like the `fixed-font-size` mode in that a basic font size can be specified by the user.\
`max-font-size`（最大字型大小）模式很類似於 `fixed-font-size`（固定字型大小）模式，它們的基本字型大小都可由使用者指定。

However, when the window is too narrow or too short, `fixed-font-size` just lets the terminal screen overflow the window, while `max-font-size` shrinks the font to keep the screen inside the window.\
但，當視窗過窄或過矮，`fixed-font-size`（固定字型大小）會直接讓終端機畫面超出視窗，而 `max-font-size`（最大字型大小）會縮小字體讓畫面維持在視窗內。

This feature should benefit users who use PttChrome on a relatively small screen (e.g., mobile/tablet users) and want to maximize the use of the limited space of their screen for reading without manually tweaking the terminal size in the `fixed-term-size` mode.\
這個功能應有利於在相對小的螢幕（例如手機或平板電腦）上使用 PttChrome，且想儘量利用閱讀時有限的螢幕空間，又不想手動調整 `fixed-term-size`（固定終端機大小）中的終端機寬高設定的使用者。

Video for demonstration 展示影片:

https://user-images.githubusercontent.com/37586669/116145093-6c677680-a70f-11eb-9983-7eadda00b09b.mp4

Note: After the recording of the video, the options for specifying the minimum height and width of the terminal screen size for `max-font-size` were dropped for the convenience of user. The minimum terminal screen size is hardcoded as 80 cols x 24 rows.\
注意：在錄完該影片後，爲了方便使用者，移除了 `max-font-size`（最大字型大小）中用來指定終端機的最小高度與寬度的選項。終端機的最小寬高寫死成 80 縱列 × 24 橫行。