### PR TITLE
feat(TwoColorWord.js): implement blinking

### DIFF
--- a/src/components/Row/WordSegmentBuilder/ColorSpan.js
+++ b/src/components/Row/WordSegmentBuilder/ColorSpan.js
@@ -3,7 +3,7 @@ import cx from "classnames";
 export const ColorSpan = ({ className, colorState, inner }) => (
   <span
     className={cx(className, `q${colorState.fg}`, `b${colorState.bg}`, {
-      [`qq${colorState.bg}`]: colorState.blink
+      qq: colorState.blink
     })}
   >
     {inner}

--- a/src/components/Row/WordSegmentBuilder/TwoColorWord.js
+++ b/src/components/Row/WordSegmentBuilder/TwoColorWord.js
@@ -2,17 +2,48 @@ import cx from "classnames";
 import { forceWidthStyle } from "./ForceWidthWord";
 
 /**
- * TODO: add blinking.
+ * TwoColorWord implements the two-color-word effect,
+ * where the first half ("head") and the last half ("tail")
+ * of a fullwidth character ("word") have different colors.
+ *
+ * The two-color-word effect is achieved by adding a half-word overlay to a word,
+ * so that the overlaid half of the word has the color of the overlay.
+ *
+ * If both the head and the tail have the same foreground color and blinking effect,
+ * the half-word overlay is not needed.
+ *
+ * The blinking effect is achieved by the following cases:
+ * - Only the tail blinks: Overlay the head and blink only the underneath word
+ * - Only the head blinks: Overlay the tail and blink only the underneath word
+ * - Both blink: Overlay the head and blink both the underneath word and the overlay
  */
 export const TwoColorWord = ({ colorLead, colorTail, forceWidth, text }) => (
   <span
     className={cx({
-      [`q${colorLead.fg}`]: colorLead.fg === colorTail.fg,
-      [`w${colorLead.fg}`]: colorLead.fg !== colorTail.fg,
-      [`q${colorTail.fg}`]: colorLead.fg !== colorTail.fg,
-      o: colorLead.fg !== colorTail.fg,
+      // classes for foreground
+      ...(colorLead.fg === colorTail.fg
+        ? {
+            // for one-color-word (including blinking differences)
+            [`q${colorLead.fg}`]: true,
+            [`w${colorTail.fg}`]: colorLead.blink !== colorTail.blink
+          }
+        : {
+            // for two-color-word with only the head blinks
+            [`q${colorLead.fg}`]: colorLead.blink && !colorTail.blink,
+            [`w${colorTail.fg}`]: colorLead.blink && !colorTail.blink,
+            // for two-color-word in other cases
+            [`w${colorLead.fg}`]: !colorLead.blink || colorTail.blink,
+            [`q${colorTail.fg}`]: !colorLead.blink || colorTail.blink
+          }),
+      // classes for the half-word overlay
+      o: colorLead.fg !== colorTail.fg || colorLead.blink !== colorTail.blink,
+      ot: colorLead.blink && !colorTail.blink, // overlay the tail instead
+      // classes for background
       [`b${colorLead.bg}`]: colorLead.bg === colorTail.bg,
       [`b${colorLead.bg}b${colorTail.bg}`]: colorLead.bg !== colorTail.bg,
+      // other classes
+      qq: colorLead.blink || colorTail.blink, // blink the underneath word
+      ww: colorLead.blink && colorTail.blink, // blink the half-word overlay
       wpadding: forceWidth
     })}
     style={forceWidthStyle(forceWidth)}

--- a/src/css/color.css
+++ b/src/css/color.css
@@ -8,23 +8,7 @@
   color: inherit;
 }
 
-.blink--active .qq{color:RGBA(0,0,0,0);background-color:inherit;}
-.blink--active .qq0{color:RGBA(0,0,0,0);background-color:inherit;}
-.blink--active .qq1{color:RGBA(0,0,0,0);background-color:#800000;}
-.blink--active .qq2{color:RGBA(0,0,0,0);background-color:#008000;}
-.blink--active .qq3{color:RGBA(0,0,0,0);background-color:#808000;}
-.blink--active .qq4{color:RGBA(0,0,0,0);background-color:#000080;}
-.blink--active .qq5{color:RGBA(0,0,0,0);background-color:#800080;}
-.blink--active .qq6{color:RGBA(0,0,0,0);background-color:#008080;}
-.blink--active .qq7{color:RGBA(0,0,0,0);background-color:#c0c0c0;}
-.blink--active .qq8{color:RGBA(0,0,0,0);background-color:#808080;}
-.blink--active .qq9{color:RGBA(0,0,0,0);background-color:#ff0000;}
-.blink--active .qq10{color:RGBA(0,0,0,0);background-color:#00ff00;}
-.blink--active .qq11{color:RGBA(0,0,0,0);background-color:#ffff00;}
-.blink--active .qq12{color:RGBA(0,0,0,0);background-color:#0000ff;}
-.blink--active .qq13{color:RGBA(0,0,0,0);background-color:#ff00ff;}
-.blink--active .qq14{color:RGBA(0,0,0,0);background-color:#00ffff;}
-.blink--active .qq15{color:RGBA(0,0,0,0);background-color:#ffffff;}
+.blink--active .qq{color:RGBA(0,0,0,0);}
 .q0{color:#000000;}
 .q1{color:#800000;}
 .q2{color:#008000;}
@@ -315,6 +299,8 @@
 .b15b15{background:-webkit-linear-gradient(left,#ffffff 50%,#ffffff 50%);}
 .o{position:relative;display:inline-block;}
 .o::after{content:attr(data-text);position:absolute;left:0px;width:50%;overflow:hidden;-webkit-user-select: none;pointer-events:none;}
+.ot::after{left:0.5em;text-indent:-0.5em;}
+.blink--active .ww::after{color:RGBA(0,0,0,0);text-shadow:none}
 .w0::after{color:#000000;text-shadow:#000000 0 0 0px,#000000 0 0 0px,#000000 0 0 0px,#000000 0 0 0px,#000000 0 0 0px;}
 .w1::after{color:#800000;text-shadow:#800000 0 0 0px,#800000 0 0 0px,#800000 0 0 0px,#800000 0 0 0px,#800000 0 0 0px;}
 .w2::after{color:#008000;text-shadow:#008000 0 0 0px,#008000 0 0 0px,#008000 0 0 0px,#008000 0 0 0px,#008000 0 0 0px;}


### PR DESCRIPTION
`TwoColorWord` achieves the two-color-word effect by adding a half-word overlay to a full-width character ("word").

By making use of the overlay, the blinking effect can be achieved by the following cases:
* Only the tail blinks: Overlay the head and blink only the underneath word
* Only the head blinks: Overlay the tail and blink only the underneath word
* Both blink: Overlay the head and blink both the underneath word and the overlay

For overlaying the tail, a negative `text-indent` is applied to the overlay to truncate off the left half of the overlay character.

The background color is handled by the `.b*` CSS classes but was also affected by the `.qq*` classes. This further complicated the `TwoColorWord` blinking implementation.

Therefore, I removed the `.qq*` classes, except for the `.qq` class, which does not affect the background color.

Demonstration:
![PttChrome 2021-05-14 TwoColorWord blinking](https://user-images.githubusercontent.com/37586669/118175483-bd42d300-b462-11eb-8440-cebbda8b3e45.gif)