### PR TITLE
fix(webpack-dev-server): work around ERR_CONNECTION_RESET

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -121,6 +121,7 @@ module.exports = {
     new HtmlWebpackHarddiskPlugin()
   ]),
   devServer: {
+    host: '0.0.0.0',
     contentBase: path.join(__dirname, './dist'),
     proxy: {
       '/bbs': {


### PR DESCRIPTION
This enables the browser to reach the page deployed with `yarn start`.

Reference: https://stackoverflow.com/questions/58511717/getting-an-err-connection-reset-with-webpack-dev-server-on-port-8080