### PR TITLE
fix(components/): fix black bg on the right half of two-color characters may not be black 修正雙色字右半的黑背景不黑的問題

### DIFF
--- a/src/components/Row/ColorSegmentBuilder.js
+++ b/src/components/Row/ColorSegmentBuilder.js
@@ -1,4 +1,4 @@
-import WordSegmentBuilder from "./WordSegmentBuilder";
+import { WordSegmentBuilder, TwoColorWordBuilder } from "./WordSegmentBuilder";
 import { b2u, isDBCSLead } from "../../js/string_util";
 import { symbolTable } from "../../js/symbol_table";
 
@@ -56,13 +56,14 @@ export class ColorSegmentBuilder {
       return;
     }
     if (!leadColor.equals(ch.getColor())) {
-      this.beginSegment(leadColor);
-      this.wordBuilder.appendTwoColorWord(
-        text,
+      this.segs.push(this.wordBuilder.build());
+      this.wordBuilder = new TwoColorWordBuilder(
+        this.segs.length,
         leadColor,
         ch.getColor(),
         this.forceWidth
       );
+      this.wordBuilder.appendNormalText(text);
       return;
     }
     const forceWidth = shouldForceWidth(text) ? this.forceWidth : 0;

--- a/src/components/Row/WordSegmentBuilder/TwoColorWord.js
+++ b/src/components/Row/WordSegmentBuilder/TwoColorWord.js
@@ -6,10 +6,8 @@ import { forceWidthStyle } from "./ForceWidthWord";
  */
 export const TwoColorWord = ({ colorLead, colorTail, forceWidth, text }) => (
   <span
-    className={cx({
-      [`q${colorLead.fg}`]: colorLead.fg === colorTail.fg,
+    className={cx(`q${colorTail.fg}`, {
       [`w${colorLead.fg}`]: colorLead.fg !== colorTail.fg,
-      [`q${colorTail.fg}`]: colorLead.fg !== colorTail.fg,
       o: colorLead.fg !== colorTail.fg,
       [`b${colorLead.bg}`]: colorLead.bg === colorTail.bg,
       [`b${colorLead.bg}b${colorTail.bg}`]: colorLead.bg !== colorTail.bg,

--- a/src/components/Row/WordSegmentBuilder/index.js
+++ b/src/components/Row/WordSegmentBuilder/index.js
@@ -32,24 +32,36 @@ export class WordSegmentBuilder {
     );
   }
 
-  appendTwoColorWord(text, colorLead, colorTail, forceWidth) {
-    this.inner.push(
-      <TwoColorWord
-        key={this.inner.length}
-        text={text}
-        colorLead={colorLead}
-        colorTail={colorTail}
-        forceWidth={forceWidth}
-      />
-    );
-  }
-
   build() {
     return (
       <ColorSpan
         key={this.key}
         colorState={this.colorState}
         inner={this.inner}
+      />
+    );
+  }
+}
+
+export class TwoColorWordBuilder extends WordSegmentBuilder {
+  constructor(key, colorState, colorTail, forceWidth) {
+    super(key, colorState);
+    this.colorTail = colorTail;
+    this.forceWidth = forceWidth;
+  }
+
+  isLastSegmentSameColor(color) {
+    return false; // forbid appending
+  }
+
+  build() {
+    return (
+      <TwoColorWord
+        key={this.key}
+        colorLead={this.colorState}
+        colorTail={this.colorTail}
+        forceWidth={this.forceWidth}
+        text={this.inner}
       />
     );
   }


### PR DESCRIPTION
This issue was described in commit a75d5501ece7a6c511984d0900af4cfcc628bcde.\
此問題已先爲 commit a75d5501ece7a6c511984d0900af4cfcc628bcde 所述。

This issue was caused by the HTML layout of two-color chars, e.g.:\
此問題由雙色字的 HTML 排版導致，範例：

```html
<span class="q15 b1">
    <span class="q15 b1b0 wpadding" data-text="Ａ" style="display: inline-block; width: 24px;">
        Ａ
    </span>
    Ｍ
</span>
```

The "black" part of the background of the inner span is actually transparent, but the outer span has its own background (of the bg color of the left-half char), thus the "black" part of the inner span appeared to be not black.\
內層 span 的背景的「黑色」部份實際上是透明的，但外層 span 有自己的背景（帶有左半雙色字的背景顏色），故內層 span 的「黑色」部份看起來並不黑。

To fix this issue, `WordSegmentBuilder` is specialized for two-color chars (as JavaScript class `TwoColorWordBuilder`) so as to instead generate such layout as:\
爲了解決這個問題，`WordSegmentBuilder` 已對雙色字特例化（爲 JavaScript 類型 `TwoColorWordBuilder`）來把前述的排版改產生爲：

```html
<span class="q15 b1b0 wpadding" data-text="Ａ" style="display: inline-block; width: 24px;">
    Ａ
</span>
<span class="q15 b1">
    Ｍ
</span>
```

This no only avoids the unwanted background color introduced by the outer span but also eliminates the unnecessary outer span for a sole two-color char.\
這不僅避免了外層 span 所導致的不想要的背景顏色，也消除了單獨出現的雙色字的不必要的外層 span。

Note that this requires a fix to `TwoColorWord.js` to make the un-nested span rendered expectedly. See the commit message for details.\
注意這需要對 `TwoColorWord.js` 修正以讓未經多層套置的 span 按預期彩現。詳見 commit 訊息。

## Test case

**測試案例**

### Current behavior 目前行爲
![image](https://user-images.githubusercontent.com/37586669/145726923-beac3813-ac6e-426f-9052-f592d144e8eb.png)

### Expected behavior (with this fix applied) 預期行爲（套用了此修正）
![image](https://user-images.githubusercontent.com/37586669/145726843-a14b03d5-32a2-407f-9ed6-8cda8522bb9f.png)

### Sample text 範例文字

- [SampleText-PCMan.txt](https://github.com/robertabcd/PttChrome/files/7699434/SampleText-PCMan.txt) (exported with PCMan)
-  [SampleText-PttChrome.txt](https://github.com/robertabcd/PttChrome/files/7699419/SampleText-PttChrome.txt) (copied with PttChrome)