### PR TITLE
refactor(js/string_util): drop redundant `new RegExp()`

### DIFF
--- a/src/js/string_util.js
+++ b/src/js/string_util.js
@@ -130,7 +130,7 @@ export function parseReqNotMetText(it) {
 };
 
 export function parseStatusRow(str) {
-  var regex = new RegExp(/  瀏覽 第 (\d{1,3})(?:\/(\d{1,3}))? 頁 *\( *(\d{1,3})%\)  目前顯示: 第 0*(\d+)~0*(\d+) 行 *(?:\(y\)回應)?(?:\(X\/?%\)推文)?(?:\(h\)說明)? *\(←\/?q?\)離開 /g);
+  var regex = /  瀏覽 第 (\d{1,3})(?:\/(\d{1,3}))? 頁 *\( *(\d{1,3})%\)  目前顯示: 第 0*(\d+)~0*(\d+) 行 *(?:\(y\)回應)?(?:\(X\/?%\)推文)?(?:\(h\)說明)? *\(←\/?q?\)離開 /g;
   var result = regex.exec(str);
 
   if (result && result.length === 6) {
@@ -147,17 +147,17 @@ export function parseStatusRow(str) {
 };
 
 export function parseListRow(str) {
-  var regex = new RegExp(/\[\d{1,2}\/\d{1,2} +星期. +\d{1,2}:\d{1,2}\] .+ 線上\d+人, 我是\w+ +\[呼叫器\](?:關閉|打開) /g);
+  var regex = /\[\d{1,2}\/\d{1,2} +星期. +\d{1,2}:\d{1,2}\] .+ 線上\d+人, 我是\w+ +\[呼叫器\](?:關閉|打開) /g;
   return regex.test(str);
 };
 
 export function parseWaterball(str) {
-  var regex = new RegExp(/\x1b\[1;33;46m\u2605(\w+)\x1b\[0;1;37;45m (.+) \x1b\[m\x1b\[K/g);
+  var regex = /\x1b\[1;33;46m\u2605(\w+)\x1b\[0;1;37;45m (.+) \x1b\[m\x1b\[K/g;
   var result = regex.exec(str);
   if (result && result.length == 3) {
     return { userId: result[1], message: result[2] };
   } else {
-    regex = new RegExp(/\x1b\[24;\d{2}H\x1b\[1;37;45m([^\x1b]+)(?:\x1b\[24;18H)?\x1b\[m/g);
+    regex = /\x1b\[24;\d{2}H\x1b\[1;37;45m([^\x1b]+)(?:\x1b\[24;18H)?\x1b\[m/g;
     result = regex.exec(str);
     if (result && result.length == 2) {
       return { message: result[1] };
@@ -169,7 +169,7 @@ export function parseWaterball(str) {
 
 export function ansiHalfColorConv(it) {
   var str = '';
-  var regex = new RegExp('\x15\\[(([0-9]+)?;)+50m', 'g');
+  var regex = /\x15\[(([0-9]+)?;)+50m/g;
   var result = null;
   var indices = [];
   while ((result = regex.exec(it))) {


### PR DESCRIPTION
This resolves robertabcd/PttChrome#77

Regex literals (codes like `/pattern/flags`) are already instances of `RegExp`, thus `new RegExp(/pattern/flags)` creates an extra copy of the `RegExp` object, which is often not intended.

This issue was introduced in [iamchucky/PttChrome](https://github.com/iamchucky/PttChrome).

This issue is fixed by rewritten `new RegExp()` codes into plain regex literals.