### PR TITLE
fix(js/term_buf): fix broken CSS cursor styling 修正壞掉的游標 CSS 樣式設定

### DIFF
--- a/src/js/term_buf.js
+++ b/src/js/term_buf.js
@@ -47,21 +47,21 @@ export const termInvColors = [
 ];
 
 const mouseCursorMap = [
-  'auto',                                               // 0
-  `url(${require('../cursor/back.png')} 0 6,auto`,      // 1
-  `url(${require('../cursor/pageup.png')} 6 0,auto`,    // 2
-  `url(${require('../cursor/pagedown.png')} 6 21,auto`, // 3
-  `url(${require('../cursor/home.png')} 0 0,auto`,      // 4
-  `url(${require('../cursor/end.png')} 0 0,auto`,       // 5
-  'pointer',                                            // 6
-  'default',                                            // 7
-  `url(${require('../cursor/prevous.png')} 6 0,auto`,   // 8
-  `url(${require('../cursor/next.png')} 6 0,auto`,      // 9
-  `url(${require('../cursor/first.png')} 0 0,auto`,     // 10
-  'auto',                                               // 11
-  `url(${require('../cursor/refresh.png')} 0 0,auto`,   // 12
-  `url(${require('../cursor/last.png')} 0 0,auto`,      // 13
-  `url(${require('../cursor/last.png')} 0 0,auto`       // 14
+  'auto',                                                // 0
+  `url(${require('../cursor/back.png')}) 0 6,auto`,      // 1
+  `url(${require('../cursor/pageup.png')}) 6 0,auto`,    // 2
+  `url(${require('../cursor/pagedown.png')}) 6 21,auto`, // 3
+  `url(${require('../cursor/home.png')}) 0 0,auto`,      // 4
+  `url(${require('../cursor/end.png')}) 0 0,auto`,       // 5
+  'pointer',                                             // 6
+  'default',                                             // 7
+  `url(${require('../cursor/prevous.png')}) 6 0,auto`,   // 8
+  `url(${require('../cursor/next.png')}) 6 0,auto`,      // 9
+  `url(${require('../cursor/first.png')}) 0 0,auto`,     // 10
+  'auto',                                                // 11
+  `url(${require('../cursor/refresh.png')}) 0 0,auto`,   // 12
+  `url(${require('../cursor/last.png')}) 0 0,auto`,      // 13
+  `url(${require('../cursor/last.png')}) 0 0,auto`       // 14
 ];
 
 function TermChar(ch) {

--- a/src/js/term_buf.js
+++ b/src/js/term_buf.js
@@ -1063,15 +1063,15 @@ TermBuf.prototype = {
     case 4: //LIST
       if (trow>1 && trow < lastRowNum-1) {              //m_pTermData->m_RowsPerPage-1
         if ( tcol <= 6 ) {
-          this.mouseCursor = 1;
           this.clearHighlight();
+          this.mouseCursor = 1;
           //SetCursor(m_ExitCursor);m_CursorState=1;
         } else if ( tcol >= cols-16 ) {            //m_pTermData->m_ColsPerPage-16
+          this.clearHighlight();
           if ( trow > 12 )
             this.mouseCursor = 3;
           else
             this.mouseCursor = 2;
-          this.clearHighlight();
         } else {
           if (!this.isLineEmpty(trow)) {
             this.mouseCursor = 6;
@@ -1092,15 +1092,15 @@ TermBuf.prototype = {
     case 2: //LIST
       if (trow > 2 && trow < lastRowNum) {              //m_pTermData->m_RowsPerPage-1
         if ( tcol <= 6 ) {
-          this.mouseCursor = 1;
           this.clearHighlight();
+          this.mouseCursor = 1;
           //SetCursor(m_ExitCursor);m_CursorState=1;
         } else if ( tcol >= cols-16 ) {            //m_pTermData->m_ColsPerPage-16
+          this.clearHighlight();
           if ( trow > 12 )
             this.mouseCursor = 3;
           else
             this.mouseCursor = 2;
-          this.clearHighlight();
         } else {
           if (!this.isLineEmpty(trow)) {
             this.mouseCursor = 6;


### PR DESCRIPTION
This PR fixes the issue that the dedicated cursor icons are not used.\
此 PR 修正專用的游標圖案沒被用到的問題。

### fix(js/term_buf): fix missing `)` of `url()` for CSS cursor style

**修正用於 CSS 游標樣式設定的 `url()` 所少了的 `)`**

The `)` was accidentally dropped in the following commit:\
這個 `)` 在下列 commit 中被不愼移除了：

*  8d8db1c62d517d1f7be200a5276c8d87fee2681e "feat(term_buf): webpack require cursor urls"

### fix(js/term_buf): fix mouseCursor overridden by `clearHighlight()`

**修正 `mouseCursor` 被 `clearHighlight()`（的效果）覆蓋的問題**

`clearHighlight()` resets `mouseCursor` to `0`, so `clearHighlight()` overrides any previous assignments to `mouseCursor`.\
`clearHighlight()` 會重設 `mouseCursor` 爲 `0`，因此 `clearHighlight()` 會覆蓋此前任何賦予 `mouseCursor` 的値。

`clearHighlight()` had only been called when there was a highlighted row, but the precondition had complicated the code and was dropped in the following commit:\
`clearHighlight()` 原只在存在被突出顯示的橫行時才會被呼叫，但此前提條件複雜化了程式碼，而在下列 commit 中去除了：

* b346f468bc5a105c5e174a1028dcc6a1651f6075 "Separate more easy reading things.".

To fix this issue, the order of `mouseCursor` assignment and `clearHighlight()` is simply swapped.\
爲了解決這個問題，對 `mouseCursor` 的賦値與對 `clearHighlight()` 的呼叫的順序已交換。

## Demostration

The behavior of mouse cursor display after applying this PR:\
在套用此 PR 後的滑鼠游標顯示行爲：

![PttChrome 2021-12-15 fix-css-cursor demo](https://user-images.githubusercontent.com/37586669/146215564-d14f8155-6044-429f-9095-cdce35dbbe92.gif)

Note: For the build in the video, in order to deal with the board-entry screen, I modified `App.prototype.onMouse_click()` to send the following keys for mouse actions:\
注意：在此影片中的程式建構版本中，爲了處理進入看板時的畫面，我修改了 `App.prototype.onMouse_click()` 來對滑鼠動作送出下列按鍵：\
- Refresh (clicking the bottom-left corner; `12`) 重新整理（按畫面左下角；`12`）: Send <kbd>←</kbd> <kbd>Enter</kbd> <kbd>End</kbd> <kbd>End</kbd>
- Last thread (clicking the bottom-right corner; `13`) 最後同主題（按畫面右下角；`13`）: Send <kbd>←</kbd> <kbd>Enter</kbd> <kbd>End</kbd> <kbd>End</kbd> <kbd>[</kbd> <kbd>]</kbd>

Before applying this PR, only the "I" cursor instead of the dedicated cursor icons is used.\
在套用此 PR 前，只有 I 字型游標被使用，而專用的游標圖案沒被用到。