### PR TITLE
fix: fix hardcoded mouse browsing background 修正寫死的滑鼠瀏覽底色

### DIFF
--- a/src/components/Row/LinkSegmentBuilder.js
+++ b/src/components/Row/LinkSegmentBuilder.js
@@ -79,7 +79,7 @@ export class LinkSegmentBuilder {
     return (
       <div>
         <span
-          className={cx({ b2: this.highlighted })}
+          className={cx({ hl: this.highlighted })}
           data-type="bbsline"
           data-row={this.row}
         >

--- a/src/css/color.css
+++ b/src/css/color.css
@@ -313,6 +313,7 @@
 .b15b13{background:-webkit-linear-gradient(left,#ffffff 50%,#ff00ff 50%);}
 .b15b14{background:-webkit-linear-gradient(left,#ffffff 50%,#00ffff 50%);}
 .b15b15{background:-webkit-linear-gradient(left,#ffffff 50%,#ffffff 50%);}
+.hl{background-color:var(--highlightBG);}
 .o{position:relative;display:inline-block;}
 .o::after{content:attr(data-text);position:absolute;left:0px;width:50%;overflow:hidden;-webkit-user-select: none;pointer-events:none;}
 .w0::after{color:#000000;text-shadow:#000000 0 0 0px,#000000 0 0 0px,#000000 0 0 0px,#000000 0 0 0px,#000000 0 0 0px;}

--- a/src/js/pttchrome.js
+++ b/src/js/pttchrome.js
@@ -796,7 +796,7 @@ App.prototype.onPrefChange = function(name, value) {
       break;
     case 'mouseBrowsingHighlightColor':
       this.view.highlightBG = value;
-      this.view.redraw(true);
+      this.view.updateHighlightColor();
       this.view.updateCursorPos();
       break;
     case 'mouseLeftFunction':

--- a/src/js/term_buf.js
+++ b/src/js/term_buf.js
@@ -4,7 +4,7 @@ import { Event } from './event';
 import { ColorState } from './term_ui';
 import { u2b, b2u, parseStatusRow, parseListRow } from './string_util';
 
-const termColors = [
+export const termColors = [
   // dark
   '#000000', // black
   '#800000', // red

--- a/src/js/term_view.js
+++ b/src/js/term_view.js
@@ -1,7 +1,7 @@
 // Terminal View
 
 import { TermKeyboard } from './term_keyboard';
-import { termInvColors } from './term_buf';
+import { termColors, termInvColors } from './term_buf';
 import { renderRowHtml, renderScreen } from './term_ui';
 import { i18n } from './i18n';
 import { setTimer } from './util';
@@ -63,6 +63,8 @@ export function TermView() {
   this.enablePicPreview = true;
   this.scaleX = 1;
   this.scaleY = 1;
+
+  this.updateHighlightColor();
 
   var dynamicStyle = document.createElement('style');
   document.head.appendChild(dynamicStyle);
@@ -300,6 +302,11 @@ TermView.prototype = {
     if (this.buf.highlightCursor) {
       this.componentScreen.setCurrentHighlighted(row)
     }
+  },
+
+  updateHighlightColor: function() {
+    this.BBSWin.style.setProperty('--highlightBG', termColors[this.highlightBG]);
+    //this.BBSWin.style.setProperty('--highlightFG', termColors[this.highlightFG]);
   },
 
   onInput: function(e) {


### PR DESCRIPTION
Relevant issue: robertabcd/PttChrome#18

The support for customizing mouse browsing background was dropped in the following commit:\
對自訂滑鼠瀏覽底色的支援已於下列 commit 中移除：

* 861847203bb2ad82f02a9b1e8aef113b46d71acf "Refactor out easy reading and rendering"

The functionality is reimplemented with the use of a new CSS variable `--highlightBG`.\
該功能已以使用新 CSS 變數 `--highlightBG` 重新實作。

## Screenshots

![image](https://user-images.githubusercontent.com/37586669/146337028-a449ca57-1df8-410a-8468-06b58fbbcab1.png)

![image](https://user-images.githubusercontent.com/37586669/146337238-602f6b1c-fdcc-4e54-8f1b-d35857c56b9b.png)
