### PR TITLE
fix pasted text ignoring options_lineWrap 修正貼上文字無視自動換行設定的問題

### DIFF
--- a/src/js/pttchrome.js
+++ b/src/js/pttchrome.js
@@ -844,7 +844,7 @@ App.prototype.onPrefChange = function(name, value) {
       this.view.dbcsDetect = value;
       break;
     case 'lineWrap':
-      this.conn.lineWrap = value;
+      this.view.lineWrap = value;
       break;
     case 'fontFace':
       var fontFace = value;


### PR DESCRIPTION
- 修正設定中的「自動換行, 當貼上的字長於」選項無效，造成貼上的文字必定會在到達橫行 78 字元處時換行的問題

When `options_lineWrap` changed, `App.view.lineWrap` was not modified and remained as 78.\
此前，當  `options_lineWrap` 改變，`App.view.lineWrap` 並未被更動且維持其値爲 `78`。

* `js/pttchrome`: `this.conn.lineWrap` -> `this.view.lineWrap`